### PR TITLE
feat: Compute boundary nodes for LHS/RHS in rewrite sets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0.113"
 [workspace.package]
 version = "0.1.0"
 authors = ["Aleks Kissinger <aleks0@gmail.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.75"
 homepage = "https://github.com/Quantomatic/quizx"
 license-file = "LICENSE"

--- a/superopt/Cargo.toml
+++ b/superopt/Cargo.toml
@@ -8,7 +8,7 @@ homepage = { workspace = true }
 license-file = { workspace = true }
 
 [dependencies]
-quizx = { workspace = true, features = ["portmatching"]}
+quizx = { workspace = true, features = ["portmatching"] }
 num = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -37,5 +37,3 @@ rstest = "0.18.2"
 [[bin]]
 name = "compile"
 required-features = ["compile"]
-version = { workspace = true }
-description = "Compile a rewrite rules to a rewriter"


### PR DESCRIPTION
Returns a list of the ZX nodes connected to the boundary nodes of the graphs.