### PR TITLE
fix: Non-causal neighbours in convex hull

### DIFF
--- a/quizx/src/flow/causal.rs
+++ b/quizx/src/flow/causal.rs
@@ -331,7 +331,6 @@ fn add_to_hull(
             // lines of the region
             let next_v = flow.next(v).expect("start is in future and exists");
             for n in graph.neighbors(next_v) {
-                dbg!(n);
                 let line_n = flow.line_idx(n);
                 if lines.contains(&line_n) && line_n != line_v {
                     add_to_hull(
@@ -349,7 +348,6 @@ fn add_to_hull(
             // lines of the region
             for n in graph.neighbors(v) {
                 let line_n = flow.line_idx(n);
-                dbg!(n);
                 if lines.contains(&line_n) && line_n != line_v {
                     add_to_hull(
                         n,

--- a/quizx/src/flow/causal.rs
+++ b/quizx/src/flow/causal.rs
@@ -26,7 +26,7 @@
 //! 4. If `v ~ f(u)`, then `u ≼ v`
 
 use std::collections::HashSet;
-use std::ops::Range;
+use std::ops::RangeInclusive;
 
 use itertools::Itertools;
 
@@ -202,19 +202,23 @@ pub struct ConvexHull {
 
 impl ConvexHull {
     /// Constructs the convex hull of a region given the graph's causal flow.
-    pub fn from_region<'a>(region: impl IntoIterator<Item = &'a V>, flow: &CausalFlow) -> Self {
+    pub fn from_region<'a>(
+        region: impl IntoIterator<Item = &'a V>,
+        graph: &impl GraphLike,
+        flow: &CausalFlow,
+    ) -> Self {
         let flow_lines = flow.lines();
 
         // For each flow line, the first and last vertices that are part of the region.
-        let mut line_min_max: Vec<Option<Range<usize>>> = vec![None; flow_lines.len()];
+        let mut line_min_max: Vec<Option<RangeInclusive<usize>>> = vec![None; flow_lines.len()];
 
         let region: HashSet<V> = region.into_iter().copied().collect();
 
+        // The lines that the region touches.
+        let lines: HashSet<_> = region.iter().map(|&v| flow.line_idx(v)).collect();
+
         for &v in &region {
-            let p = flow.positions[v];
-            let min_max = line_min_max[p.line].get_or_insert_with(|| p.pos..p.pos);
-            min_max.start = min_max.start.min(p.pos);
-            min_max.end = min_max.end.max(p.pos);
+            add_to_hull(v, graph, &mut line_min_max, flow, &lines, None);
         }
 
         let mut hull_vertices = HashSet::new();
@@ -223,8 +227,8 @@ impl ConvexHull {
         for (line, min_max) in line_min_max.iter().enumerate() {
             if let Some(range) = min_max {
                 let line = &flow_lines[line];
-                inputs.push(line[range.start]);
-                outputs.push(line[range.end - 1]);
+                inputs.push(line[*range.start()]);
+                outputs.push(line[*range.end()]);
                 for v in line[range.clone()].iter().copied() {
                     if !region.contains(&v) {
                         hull_vertices.insert(v);
@@ -271,6 +275,101 @@ pub enum CausalFlowError {
     NonCausal,
 }
 
+/// Add vertex `v` along with further vertices as required so that the hull
+/// remains convex.
+///
+/// Rules for adding vertices:
+///  - if `v` is in the past of the current hull:
+///     1. add vertices from v to the beginning of the hull along the causal path
+///     2. add non-causal neighbours of the successor of `v`
+///  - if `v` is in the future of the current hull:
+///     1. add vertices from the end of the hull to `v` along the causal path
+///     2. add non-causal neighbours of `v`
+/// These rules must be applied recursively
+fn add_to_hull(
+    v: V,
+    graph: &impl GraphLike,
+    hull_intervals: &mut Vec<Option<RangeInclusive<usize>>>,
+    flow: &CausalFlow,
+    lines: &HashSet<usize>,
+    exclude_vertices: Option<HashSet<V>>,
+) {
+    let p = flow.positions[v];
+    let line_v = p.line;
+    // A set of vertices to be excluded from consideration, as they are being
+    // processed higher up the call stack (to avoid infinite recursion).
+    let mut exclude_vertices = exclude_vertices.unwrap_or_default();
+    if !exclude_vertices.insert(v) {
+        return;
+    }
+    if let Some(interval) = hull_intervals[line_v].as_ref().cloned() {
+        // Fill the interval between p.pos and old interval
+        if p.pos + 1 < *interval.start() {
+            let next_v = flow.next(v).expect("start is in future and exists");
+            add_to_hull(
+                next_v,
+                graph,
+                hull_intervals,
+                flow,
+                lines,
+                exclude_vertices.clone().into(),
+            );
+        } else if p.pos - 1 > *interval.end() {
+            let prev_v = flow.pred(v).expect("end is in past and exists");
+            add_to_hull(
+                prev_v,
+                graph,
+                hull_intervals,
+                flow,
+                lines,
+                exclude_vertices.clone().into(),
+            );
+        }
+        // Add neighbours to convex hull
+        if p.pos < *interval.start() {
+            // Add the non-causal neighbours of the next vertex that are on
+            // lines of the region
+            let next_v = flow.next(v).expect("start is in future and exists");
+            for n in graph.neighbors(next_v) {
+                dbg!(n);
+                let line_n = flow.line_idx(n);
+                if lines.contains(&line_n) && line_n != line_v {
+                    add_to_hull(
+                        n,
+                        graph,
+                        hull_intervals,
+                        flow,
+                        lines,
+                        exclude_vertices.clone().into(),
+                    );
+                }
+            }
+        } else if p.pos > *interval.end() {
+            // Add the non-causal neighbours of the current vertex that are on
+            // lines of the region
+            for n in graph.neighbors(v) {
+                let line_n = flow.line_idx(n);
+                dbg!(n);
+                if lines.contains(&line_n) && line_n != line_v {
+                    add_to_hull(
+                        n,
+                        graph,
+                        hull_intervals,
+                        flow,
+                        lines,
+                        exclude_vertices.clone().into(),
+                    );
+                }
+            }
+        }
+        let start = (*interval.start()).min(p.pos);
+        let end = (*interval.end()).max(p.pos);
+        hull_intervals[line_v] = Some(start..=end);
+    } else {
+        hull_intervals[line_v] = Some(p.pos..=p.pos);
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -311,6 +410,7 @@ mod test {
         g.add_edge(vs[2], vs[4]);
         g.add_edge(vs[2], vs[3]);
         g.add_edge(vs[3], vs[5]);
+        g.add_edge(vs[4], vs[5]);
         g.add_edge(vs[4], vs[6]);
         g.add_edge(vs[5], vs[7]);
         (g, vs)
@@ -336,9 +436,9 @@ mod test {
         let flow = CausalFlow::from_graph(&g).unwrap();
 
         let region = vec![vs[0], vs[3], vs[6], vs[4]];
-        let expected_other = [vs[2]];
+        let expected_other = [vs[2], vs[5]];
 
-        let hull = ConvexHull::from_region(&region, &flow);
+        let hull = ConvexHull::from_region(&region, &g, &flow);
 
         assert_eq!(hull.region, region.iter().copied().collect());
         assert_eq!(hull.hull_vertices, expected_other.iter().copied().collect());
@@ -352,7 +452,7 @@ mod test {
         let region = vec![vs[2], vs[3], vs[5]];
         let expected_other = [vs[4]];
 
-        let hull = ConvexHull::from_region(&region, &flow);
+        let hull = ConvexHull::from_region(&region, &g, &flow);
 
         assert_eq!(hull.region, region.iter().copied().collect());
         assert_eq!(hull.hull_vertices, expected_other.iter().copied().collect());
@@ -366,7 +466,21 @@ mod test {
         let region = vec![vs[2], vs[3], vs[5], vs[7]];
         let expected_other = [vs[4]];
 
-        let hull = ConvexHull::from_region(&region, &flow);
+        let hull = ConvexHull::from_region(&region, &g, &flow);
+
+        assert_eq!(hull.region, region.iter().copied().collect());
+        assert_eq!(hull.hull_vertices, expected_other.iter().copied().collect());
+    }
+
+    #[rstest]
+    fn convex_hull4(simple_graph: (Graph, Vec<V>)) {
+        let (g, vs) = simple_graph;
+        let flow = CausalFlow::from_graph(&g).unwrap();
+
+        let region = vec![vs[2], vs[4], vs[5]];
+        let expected_other = [];
+
+        let hull = ConvexHull::from_region(&region, &g, &flow);
 
         assert_eq!(hull.region, region.iter().copied().collect());
         assert_eq!(hull.hull_vertices, expected_other.iter().copied().collect());

--- a/quizx/src/flow/causal.rs
+++ b/quizx/src/flow/causal.rs
@@ -343,4 +343,32 @@ mod test {
         assert_eq!(hull.region, region.iter().copied().collect());
         assert_eq!(hull.hull_vertices, expected_other.iter().copied().collect());
     }
+
+    #[rstest]
+    fn convex_hull2(simple_graph: (Graph, Vec<V>)) {
+        let (g, vs) = simple_graph;
+        let flow = CausalFlow::from_graph(&g).unwrap();
+
+        let region = vec![vs[2], vs[3], vs[5]];
+        let expected_other = [vs[4]];
+
+        let hull = ConvexHull::from_region(&region, &flow);
+
+        assert_eq!(hull.region, region.iter().copied().collect());
+        assert_eq!(hull.hull_vertices, expected_other.iter().copied().collect());
+    }
+
+    #[rstest]
+    fn convex_hull3(simple_graph: (Graph, Vec<V>)) {
+        let (g, vs) = simple_graph;
+        let flow = CausalFlow::from_graph(&g).unwrap();
+
+        let region = vec![vs[2], vs[3], vs[5], vs[7]];
+        let expected_other = [vs[4]];
+
+        let hull = ConvexHull::from_region(&region, &flow);
+
+        assert_eq!(hull.region, region.iter().copied().collect());
+        assert_eq!(hull.hull_vertices, expected_other.iter().copied().collect());
+    }
 }

--- a/superopt/src/main.rs
+++ b/superopt/src/main.rs
@@ -5,10 +5,10 @@ use std::time::Instant;
 
 use clap::Parser;
 use quizx::circuit::Circuit;
-use quizx::json::{read_graph, write_graph};
-use quizx::vec_graph::Graph;
 use quizx::graph::GraphLike;
+use quizx::json::{read_graph, write_graph};
 use quizx::simplify::spider_simp;
+use quizx::vec_graph::Graph;
 use quizx_superopt::rewriter::CausalRewriter;
 use quizx_superopt::superopt::{SuperOptOptions, SuperOptimizer};
 
@@ -83,8 +83,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         graph = circ.to_basic_gates().to_graph();
         graph.x_to_z();
         spider_simp(&mut graph);
-    }
-    else {
+    } else {
         graph = read_graph(&args.input).unwrap_or_else(|e| {
             panic!(
                 "Could not read input graph {}.\n{e}",

--- a/superopt/src/rewriter.rs
+++ b/superopt/src/rewriter.rs
@@ -70,7 +70,7 @@ impl<G: GraphLike> Rewrite<G> {
     ///
     /// TODO: This can be done faster by pre-computing a "causal structure"
     fn is_flow_preserving(&self, graph: &impl GraphLike, flow: &CausalFlow) -> bool {
-        let hull = ConvexHull::from_region(self.lhs_vertices(), flow);
+        let hull = ConvexHull::from_region(self.lhs_vertices(), graph, flow);
         let mut subgraph = graph.induced_subgraph(hull.vertices());
         subgraph.set_inputs(hull.inputs().to_owned());
         subgraph.set_outputs(hull.outputs().to_owned());


### PR DESCRIPTION
The hand waivy definition of convexity I gave wasn't quite right.

It is correct that on every line, a convex region forms an interval (as was implemented), however that interval isn't necessary the smallest such interval:

In the graph

```text
0 - 2 - 4 - 6
    |   |
1 - 3 - 5 - 7
```

the convex hull of the region [2, 3, 4] must include 5. See the docstring for `add_to_hull` for the criteria.